### PR TITLE
Add OIDC (OpenID Connect) authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,14 @@ Non-admin users can search for books and make requests but do not have access to
 
 LDAP Users are also supported via Users > Advanced.
 
+OIDC (OpenID Connect) sign-in is also supported via Users > Advanced. When enabled, the
+login page shows a "Sign in with [provider]" button alongside the username/password form.
+Configure with your IdP's issuer URL, client ID, and client secret. Optional toggles:
+- **Auto-create users on first login**: provision new users on successful OIDC sign-in (off by default)
+- **Auto-redirect to OIDC on login page**: skip the username/password form and go straight to the IdP. If your IdP later becomes unreachable, append `?bypass=1` to the login URL (`/login?bypass=1`) to surface the local form again without editing config on disk.
+
+The redirect URI to register at your IdP is `https://<your-libreseerr-host>/api/auth/oidc/callback`.
+
 ![Libreseerr Users Page](screenshots/users.png)
 
 ## Environment Variables

--- a/app.py
+++ b/app.py
@@ -10,6 +10,7 @@ from functools import wraps
 import requests as http_requests
 from flask import Flask, jsonify, render_template, request, redirect, url_for
 from flask_login import LoginManager, login_user, logout_user, login_required, current_user
+from werkzeug.middleware.proxy_fix import ProxyFix
 from werkzeug.security import generate_password_hash, check_password_hash
 
 try:
@@ -18,11 +19,23 @@ try:
 except ImportError:
     LDAP3_AVAILABLE = False
 
+try:
+    import oidc as oidc_helper
+    OIDC_AVAILABLE = True
+except ImportError:
+    OIDC_AVAILABLE = False
+
 from bookshelf import BookshelfClient
 from readarr import ReadarrClient
 from lazylibrarian import LazyLibrarianClient
 
 app = Flask(__name__)
+
+# Honor X-Forwarded-* headers from a reverse proxy (haproxy, nginx, traefik, etc.)
+# so url_for(..., _external=True) generates correct https URLs. Required for the
+# OIDC redirect_uri to match what's registered at the IdP when the app sits
+# behind a proxy. No-op when no proxy is in front (headers absent).
+app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1, x_prefix=1)
 
 
 def _load_or_create_secret_key():
@@ -56,7 +69,7 @@ REQUESTS_FILE = os.path.join(os.path.dirname(__file__), "data", "requests.json")
 USERS_FILE = os.path.join(os.path.dirname(__file__), "data", "users.json")
 
 # In-memory state
-config = {"ebook": {}, "audiobook": {}, "ldap": {}}
+config = {"ebook": {}, "audiobook": {}, "ldap": {}, "oidc": {}}
 requests_history = []
 users = []
 lock = threading.Lock()
@@ -201,6 +214,9 @@ load_requests()
 load_users()
 init_default_admin()
 
+if OIDC_AVAILABLE:
+    oidc_helper.init_oidc(app, config)
+
 
 @app.before_request
 def reload_state():
@@ -208,6 +224,10 @@ def reload_state():
     load_config()
     load_requests()
     load_users()
+    # Re-init the OIDC client if config changed in another worker. init_oidc
+    # is idempotent — registers/unregisters the client based on enabled flag.
+    if OIDC_AVAILABLE and not app.extensions.get("oidc_client") and config.get("oidc", {}).get("enabled"):
+        oidc_helper.init_oidc(app, config)
 
 
 # ─── LDAP Auth ───
@@ -497,6 +517,165 @@ def test_ldap():
         return jsonify({"success": True, "message": "Connected to LDAP server successfully"})
     except Exception as e:
         return jsonify({"error": str(e)}), 400
+
+
+# ─── OIDC Config API ───
+
+@app.route("/api/oidc", methods=["GET"])
+@admin_required
+def get_oidc():
+    if not OIDC_AVAILABLE:
+        return jsonify({
+            "available": False,
+            "enabled": False, "display_name": "OIDC", "issuer_url": "",
+            "client_id": "", "client_secret": "", "scope": "openid profile email",
+            "username_claim": "preferred_username", "default_role": "user",
+            "auto_create_users": False, "auto_redirect": False,
+        })
+    defaults = oidc_helper.get_oidc_defaults()
+    oidc = config.get("oidc", defaults)
+    return jsonify({
+        "available": True,
+        "enabled": oidc.get("enabled", False),
+        "display_name": oidc.get("display_name", defaults["display_name"]),
+        "issuer_url": oidc.get("issuer_url", ""),
+        "client_id": oidc.get("client_id", ""),
+        "client_secret": oidc.get("client_secret", ""),
+        "scope": oidc.get("scope", defaults["scope"]),
+        "username_claim": oidc.get("username_claim", defaults["username_claim"]),
+        "default_role": oidc.get("default_role", "user"),
+        "auto_create_users": oidc.get("auto_create_users", False),
+        "auto_redirect": oidc.get("auto_redirect", False),
+    })
+
+
+@app.route("/api/oidc", methods=["POST"])
+@admin_required
+def update_oidc():
+    if not OIDC_AVAILABLE:
+        return jsonify({"error": "authlib library is not installed"}), 400
+    data = request.json
+    if data.get("default_role") not in ("admin", "user"):
+        return jsonify({"error": "Role must be 'admin' or 'user'"}), 400
+    config["oidc"] = {
+        "enabled": bool(data.get("enabled")),
+        "display_name": data.get("display_name", "").strip() or "OIDC",
+        "issuer_url": data.get("issuer_url", "").strip(),
+        "client_id": data.get("client_id", "").strip(),
+        "client_secret": data.get("client_secret", ""),
+        "scope": data.get("scope", "").strip() or "openid profile email",
+        "username_claim": data.get("username_claim", "").strip() or "preferred_username",
+        "default_role": data.get("default_role", "user"),
+        "auto_create_users": bool(data.get("auto_create_users")),
+        "auto_redirect": bool(data.get("auto_redirect")),
+    }
+    save_config()
+    # Re-register the OAuth client so the new config takes effect immediately.
+    oidc_helper.init_oidc(app, config)
+    return jsonify({"success": True})
+
+
+@app.route("/api/oidc/test", methods=["POST"])
+@admin_required
+def test_oidc():
+    if not OIDC_AVAILABLE:
+        return jsonify({"error": "authlib library is not installed"}), 400
+    data = request.json
+    issuer_url = data.get("issuer_url", "").strip()
+    if not issuer_url:
+        return jsonify({"error": "issuer_url is required"}), 400
+    try:
+        doc = oidc_helper.fetch_discovery(issuer_url)
+        ok, msg = oidc_helper.validate_discovery(doc)
+        if not ok:
+            return jsonify({"error": msg}), 400
+        return jsonify({
+            "success": True,
+            "message": f"Discovery OK. Issuer: {doc.get('issuer', '')}",
+        })
+    except Exception as e:
+        return jsonify({"error": str(e)}), 400
+
+
+# ─── OIDC Auth Flow ───
+
+@app.route("/api/auth/oidc/login")
+def oidc_login():
+    """Initiates the OIDC redirect to the IdP."""
+    if not OIDC_AVAILABLE or not config.get("oidc", {}).get("enabled"):
+        return redirect(url_for("login"))
+    client = oidc_helper.get_client(app)
+    if client is None:
+        # Configured but client failed to init (bad issuer, etc.) — fall back.
+        return redirect(url_for("login"))
+    redirect_uri = url_for("oidc_callback", _external=True)
+    return client.authorize_redirect(redirect_uri)
+
+
+@app.route("/api/auth/oidc/callback")
+def oidc_callback():
+    """Handles the redirect back from the IdP, exchanges code for tokens,
+    finds or provisions the user, logs them in."""
+    oidc_cfg = config.get("oidc", {})
+    if not OIDC_AVAILABLE or not oidc_cfg.get("enabled"):
+        return redirect(url_for("login"))
+    client = oidc_helper.get_client(app)
+    if client is None:
+        return redirect(url_for("login") + "?error=oidc_not_initialized")
+    try:
+        token = client.authorize_access_token()
+    except Exception as e:
+        app.logger.warning("OIDC token exchange failed: %s", e)
+        return redirect(url_for("login") + "?error=oidc_token_exchange_failed")
+
+    userinfo = token.get("userinfo")
+    if not userinfo:
+        try:
+            userinfo = client.userinfo(token=token)
+        except Exception as e:
+            app.logger.warning("OIDC userinfo fetch failed: %s", e)
+            return redirect(url_for("login") + "?error=oidc_userinfo_failed")
+
+    username = oidc_helper.extract_username(userinfo, oidc_cfg.get("username_claim", "preferred_username"))
+    if not username:
+        app.logger.warning("OIDC token contains no usable username claim: %s", userinfo)
+        return redirect(url_for("login") + "?error=oidc_no_username")
+
+    existing = next((u for u in users if u["username"] == username), None)
+    if not existing:
+        if not oidc_cfg.get("auto_create_users"):
+            app.logger.info("OIDC login rejected for '%s' — user does not exist and auto_create_users is off", username)
+            return redirect(url_for("login") + "?error=account_not_found")
+        existing = {
+            "username": username,
+            "password_hash": "oidc",
+            "role": oidc_cfg.get("default_role", "user"),
+            "auth_source": "oidc",
+            "created_at": datetime.utcnow().isoformat(),
+        }
+        users.append(existing)
+        save_users()
+        app.logger.info("Auto-provisioned OIDC user '%s'", username)
+
+    login_user(User(existing))
+    return redirect(url_for("index"))
+
+
+# ─── Auth provider discovery (for login page UI) ───
+
+@app.route("/api/auth/providers", methods=["GET"])
+def auth_providers():
+    """Tells the login page which alt providers (beyond local username/password)
+    are enabled, so it can render the appropriate buttons. Public — no auth
+    required, since the login page is itself public."""
+    oidc_cfg = config.get("oidc") or {}
+    return jsonify({
+        "oidc": {
+            "enabled": bool(OIDC_AVAILABLE and oidc_cfg.get("enabled")),
+            "display_name": oidc_cfg.get("display_name") or "OIDC",
+            "auto_redirect": bool(oidc_cfg.get("auto_redirect")),
+        },
+    })
 
 
 # ─── Config API ───

--- a/oidc.py
+++ b/oidc.py
@@ -1,0 +1,110 @@
+"""OIDC (OpenID Connect) authentication helpers.
+
+Mirrors the shape of the LDAP integration in app.py: a small set of
+module-level functions that the main app calls. The OAuth client is held
+on the Flask app's `extensions` dict to avoid a module-level singleton
+that would survive across reconfigures.
+"""
+
+import logging
+
+import requests
+from authlib.integrations.flask_client import OAuth
+
+logger = logging.getLogger(__name__)
+
+
+# Authlib uses this name to look up the registered client.
+PROVIDER_NAME = "oidc"
+
+
+def get_oidc_defaults():
+    return {
+        "enabled": False,
+        "display_name": "OIDC",
+        "issuer_url": "",
+        "client_id": "",
+        "client_secret": "",
+        "scope": "openid profile email",
+        "username_claim": "preferred_username",
+        "default_role": "user",
+        "auto_create_users": False,
+        "auto_redirect": False,
+    }
+
+
+def init_oidc(app, config):
+    """Configure the OAuth client from config['oidc'].
+
+    Called at startup AND any time config['oidc'] changes (POST /api/oidc).
+    Stores the OAuth client on app.extensions['oidc_client'] when enabled,
+    or removes it when disabled.
+    """
+    oidc_cfg = config.get("oidc") or {}
+    if not oidc_cfg.get("enabled"):
+        app.extensions.pop("oidc_client", None)
+        return False
+
+    issuer = (oidc_cfg.get("issuer_url") or "").rstrip("/")
+    client_id = oidc_cfg.get("client_id") or ""
+    client_secret = oidc_cfg.get("client_secret") or ""
+    scope = oidc_cfg.get("scope") or "openid profile email"
+
+    if not issuer or not client_id or not client_secret:
+        logger.warning("OIDC enabled but missing issuer_url/client_id/client_secret")
+        app.extensions.pop("oidc_client", None)
+        return False
+
+    oauth = OAuth(app)
+    oauth.register(
+        name=PROVIDER_NAME,
+        client_id=client_id,
+        client_secret=client_secret,
+        # Authlib auto-fetches authorization_endpoint, token_endpoint,
+        # jwks_uri, userinfo_endpoint, etc. from the discovery document.
+        server_metadata_url=f"{issuer}/.well-known/openid-configuration",
+        client_kwargs={"scope": scope},
+    )
+    app.extensions["oidc_client"] = oauth.create_client(PROVIDER_NAME)
+    return True
+
+
+def get_client(app):
+    return app.extensions.get("oidc_client")
+
+
+def fetch_discovery(issuer_url):
+    """Fetch the OIDC discovery document. Used by /api/oidc/test.
+
+    Returns the parsed JSON. Raises on HTTP or parse error.
+    """
+    url = f"{issuer_url.rstrip('/')}/.well-known/openid-configuration"
+    resp = requests.get(url, timeout=10)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def validate_discovery(doc):
+    """Basic structural validation of the discovery doc.
+
+    Returns (ok, message). The required claims are per RFC 8414 / OIDC Discovery 1.0.
+    """
+    required = ("issuer", "authorization_endpoint", "token_endpoint", "jwks_uri")
+    missing = [k for k in required if not doc.get(k)]
+    if missing:
+        return False, f"Discovery doc missing required fields: {', '.join(missing)}"
+    return True, "Discovery document looks valid"
+
+
+def extract_username(userinfo, claim_name):
+    """Pull the chosen claim from userinfo, with sensible fallbacks.
+
+    Order: configured claim, then preferred_username, then sub. Returns
+    None only if all three are missing — in which case the IdP is broken
+    and there's nothing we can do.
+    """
+    for k in (claim_name, "preferred_username", "sub"):
+        v = userinfo.get(k) if k else None
+        if v:
+            return str(v).strip()
+    return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ flask-login==0.6.3
 ldap3==2.9.1
 requests==2.32.3
 gunicorn==23.0.0
+authlib==1.3.2

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -87,7 +87,7 @@ document.querySelectorAll(".sidebar-link").forEach((link) => {
         document.getElementById(pageId).classList.add("active");
         if (link.dataset.page === "requests") loadRequests();
         if (link.dataset.page === "settings") loadConfig();
-        if (link.dataset.page === "users") { loadUsers(); loadLDAP(); }
+        if (link.dataset.page === "users") { loadUsers(); loadLDAP(); loadOIDC(); }
         closeSidebar();
     });
 });
@@ -749,6 +749,93 @@ window.testLDAP = async function () {
                 bind_password: document.getElementById("ldap-bind-password").value,
                 base_dn: document.getElementById("ldap-base-dn").value,
                 user_search_filter: document.getElementById("ldap-search-filter").value,
+            }),
+        });
+        const data = await resp.json();
+        if (data.success) {
+            statusEl.className = "status-msg success";
+            statusEl.textContent = data.message;
+        } else {
+            statusEl.className = "status-msg error";
+            statusEl.textContent = "Failed: " + data.error;
+        }
+    } catch (err) {
+        statusEl.className = "status-msg error";
+        statusEl.textContent = "Error: " + err.message;
+    }
+};
+
+// ─── OIDC Configuration ───
+
+async function loadOIDC() {
+    try {
+        const resp = await fetch("/api/oidc");
+        const data = await resp.json();
+        const unavailableEl = document.getElementById("oidc-unavailable");
+        if (data.available === false) {
+            if (unavailableEl) unavailableEl.style.display = "block";
+        } else if (unavailableEl) {
+            unavailableEl.style.display = "none";
+        }
+        document.getElementById("oidc-enabled").checked = data.enabled || false;
+        document.getElementById("oidc-display-name").value = data.display_name || "OIDC";
+        document.getElementById("oidc-issuer-url").value = data.issuer_url || "";
+        document.getElementById("oidc-client-id").value = data.client_id || "";
+        document.getElementById("oidc-client-secret").value = data.client_secret || "";
+        document.getElementById("oidc-scope").value = data.scope || "openid profile email";
+        document.getElementById("oidc-username-claim").value = data.username_claim || "preferred_username";
+        document.getElementById("oidc-default-role").value = data.default_role || "user";
+        document.getElementById("oidc-auto-create").checked = data.auto_create_users || false;
+        document.getElementById("oidc-auto-redirect").checked = data.auto_redirect || false;
+    } catch (err) {
+        console.error("Failed to load OIDC config", err);
+    }
+}
+
+window.saveOIDC = async function () {
+    const statusEl = document.getElementById("oidc-status");
+    try {
+        const resp = await fetch("/api/oidc", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                enabled: document.getElementById("oidc-enabled").checked,
+                display_name: document.getElementById("oidc-display-name").value,
+                issuer_url: document.getElementById("oidc-issuer-url").value,
+                client_id: document.getElementById("oidc-client-id").value,
+                client_secret: document.getElementById("oidc-client-secret").value,
+                scope: document.getElementById("oidc-scope").value,
+                username_claim: document.getElementById("oidc-username-claim").value,
+                default_role: document.getElementById("oidc-default-role").value,
+                auto_create_users: document.getElementById("oidc-auto-create").checked,
+                auto_redirect: document.getElementById("oidc-auto-redirect").checked,
+            }),
+        });
+        const data = await resp.json();
+        if (data.error) {
+            statusEl.className = "status-msg error";
+            statusEl.textContent = data.error;
+        } else {
+            statusEl.className = "status-msg success";
+            statusEl.textContent = "OIDC configuration saved!";
+        }
+    } catch (err) {
+        statusEl.className = "status-msg error";
+        statusEl.textContent = "Error: " + err.message;
+    }
+    setTimeout(() => { statusEl.textContent = ""; }, 3000);
+};
+
+window.testOIDC = async function () {
+    const statusEl = document.getElementById("oidc-status");
+    statusEl.className = "status-msg";
+    statusEl.textContent = "Testing...";
+    try {
+        const resp = await fetch("/api/oidc/test", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                issuer_url: document.getElementById("oidc-issuer-url").value,
             }),
         });
         const data = await resp.json();

--- a/templates/index.html
+++ b/templates/index.html
@@ -199,6 +199,73 @@
                             </div>
                             <div id="ldap-status" class="status-msg"></div>
                         </div>
+                        <div class="settings-card" style="margin-top: 1rem;">
+                            <h3>OIDC Configuration</h3>
+                            <div id="oidc-unavailable" class="status-msg error" style="display: none; margin-bottom: 0.75rem;">
+                                authlib library is not installed. Add <code>authlib</code> to requirements.txt and rebuild the image to enable OIDC.
+                            </div>
+                            <div class="form-group">
+                                <label class="toggle-label">
+                                    <input type="checkbox" id="oidc-enabled">
+                                    Enable OIDC Authentication
+                                </label>
+                            </div>
+                            <div class="form-group">
+                                <label for="oidc-display-name">Display Name</label>
+                                <input type="text" id="oidc-display-name" placeholder="Authentik">
+                            </div>
+                            <div class="form-group">
+                                <label for="oidc-issuer-url">Issuer URL</label>
+                                <input type="text" id="oidc-issuer-url" placeholder="https://auth.example.com/application/o/libreseerr/">
+                            </div>
+                            <div class="form-group">
+                                <label for="oidc-client-id">Client ID</label>
+                                <input type="text" id="oidc-client-id" placeholder="Client ID from your IdP">
+                            </div>
+                            <div class="form-group">
+                                <label for="oidc-client-secret">Client Secret</label>
+                                <input type="password" id="oidc-client-secret" placeholder="Client secret from your IdP">
+                            </div>
+                            <div class="form-group">
+                                <label for="oidc-scope">Scope</label>
+                                <input type="text" id="oidc-scope" placeholder="openid profile email">
+                            </div>
+                            <div class="form-group">
+                                <label for="oidc-username-claim">Username Claim</label>
+                                <select id="oidc-username-claim">
+                                    <option value="preferred_username">preferred_username</option>
+                                    <option value="sub">sub</option>
+                                    <option value="email">email</option>
+                                </select>
+                            </div>
+                            <div class="form-group">
+                                <label for="oidc-default-role">Default Role for New OIDC Users</label>
+                                <select id="oidc-default-role">
+                                    <option value="user">User</option>
+                                    <option value="admin">Admin</option>
+                                </select>
+                            </div>
+                            <div class="form-group">
+                                <label class="toggle-label">
+                                    <input type="checkbox" id="oidc-auto-create">
+                                    Auto-create users on first login
+                                </label>
+                            </div>
+                            <div class="form-group">
+                                <label class="toggle-label">
+                                    <input type="checkbox" id="oidc-auto-redirect">
+                                    Auto-redirect to OIDC on login page
+                                </label>
+                                <small style="display: block; margin-top: 0.25rem; color: var(--text-muted, #9ca3af); font-size: 0.75rem;">
+                                    If your IdP becomes unreachable, append <code>?bypass=1</code> to the login URL to show the local form.
+                                </small>
+                            </div>
+                            <div class="btn-group">
+                                <button class="btn btn-secondary" onclick="testOIDC()">Test Connection</button>
+                                <button class="btn btn-primary" onclick="saveOIDC()">Save</button>
+                            </div>
+                            <div id="oidc-status" class="status-msg"></div>
+                        </div>
                     </details>
                 </div>
             </div>

--- a/templates/login.html
+++ b/templates/login.html
@@ -144,6 +144,49 @@
             color: var(--text-muted);
             font-size: 0.7rem;
         }
+
+        .login-divider {
+            align-items: center;
+            text-align: center;
+            color: var(--text-muted);
+            font-size: 0.7rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            margin: 1.25rem 0 1rem;
+            display: none;
+        }
+
+        .login-divider::before,
+        .login-divider::after {
+            content: "";
+            flex: 1;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .login-divider span { padding: 0 0.625rem; }
+
+        .login-btn-secondary {
+            display: none;
+            width: 100%;
+            padding: 0.625rem;
+            background: var(--bg-primary);
+            border: 1px solid var(--border-color);
+            color: var(--text-primary);
+            border-radius: 0.5rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+            cursor: pointer;
+            font-family: inherit;
+            text-decoration: none;
+            text-align: center;
+            transition: all 0.2s;
+            box-sizing: border-box;
+        }
+
+        .login-btn-secondary:hover {
+            background: var(--bg-hover);
+            border-color: var(--pink-primary);
+        }
     </style>
 </head>
 <body>
@@ -166,10 +209,51 @@
                 </div>
                 <button type="submit" class="login-btn" id="login-btn">Sign In</button>
             </form>
+            <div class="login-divider" id="login-divider"><span>or</span></div>
+            <a href="/api/auth/oidc/login" class="login-btn-secondary" id="oidc-login-btn">Sign in with OIDC</a>
         </div>
         <div class="login-footer">Libreseerr &mdash; Book Request Management</div>
     </div>
     <script>
+        // Surface OIDC error codes from the callback redirect.
+        const params = new URLSearchParams(window.location.search);
+        const oidcError = params.get("error");
+        // Anti-lockout: ?bypass=1 keeps the local form visible even when
+        // auto-redirect is enabled. Lets admins recover without editing
+        // config on disk if their IdP becomes unreachable.
+        const oidcBypass = params.has("bypass");
+        if (oidcError) {
+            const map = {
+                account_not_found: "No matching account. Ask an admin to create one or enable auto-create.",
+                oidc_token_exchange_failed: "OIDC token exchange failed. Check provider config.",
+                oidc_userinfo_failed: "OIDC userinfo fetch failed. Check provider config.",
+                oidc_no_username: "OIDC token had no usable username claim.",
+                oidc_not_initialized: "OIDC is enabled but the client failed to initialize. Check the issuer URL.",
+            };
+            const errorEl = document.getElementById("login-error");
+            errorEl.textContent = map[oidcError] || "OIDC sign-in failed.";
+            errorEl.style.display = "block";
+        }
+
+        // Discover available alt providers and reveal the OIDC button if enabled.
+        // If auto_redirect is set, fire the redirect immediately rather than
+        // showing the form. An error in the URL suppresses auto-redirect so
+        // the user can read what went wrong.
+        fetch("/api/auth/providers")
+            .then(r => r.json())
+            .then(p => {
+                const oidc = p.oidc || {};
+                if (!oidc.enabled) return;
+                const btn = document.getElementById("oidc-login-btn");
+                btn.textContent = "Sign in with " + (oidc.display_name || "OIDC");
+                btn.style.display = "block";
+                document.getElementById("login-divider").style.display = "flex";
+                if (oidc.auto_redirect && !oidcError && !oidcBypass) {
+                    window.location.href = "/api/auth/oidc/login";
+                }
+            })
+            .catch(() => { /* network hiccup — fall back to form-only */ });
+
         document.getElementById("login-form").addEventListener("submit", async (e) => {
             e.preventDefault();
             const btn = document.getElementById("login-btn");


### PR DESCRIPTION
Adds OIDC as a third auth path alongside local username/password and LDAP, configured via Users → Advanced (mirrors the LDAP card pattern). Settings persist to data/config.json. Auto-creation of users on first OIDC login is opt-in and off by default. Auto-redirect option for OIDC-only deployments includes a ?bypass=1 escape hatch on the login URL for IdP-down recovery.

- New oidc.py module with Authlib-based OAuth client
- New routes: /api/auth/oidc/login, /api/auth/oidc/callback, /api/oidc (GET/POST), /api/oidc/test, /api/auth/providers
- ProxyFix middleware so redirect_uri generation is correct behind a reverse proxy (required for OIDC; harmless otherwise)
- Existing local + LDAP flows untouched

Tested against Authentik with auto-create enabled.