### PR TITLE
fix(oidc): fetch userinfo endpoint when id_token lacks username claims

### DIFF
--- a/app.py
+++ b/app.py
@@ -629,9 +629,11 @@ def oidc_callback():
         return redirect(url_for("login") + "?error=oidc_token_exchange_failed")
 
     userinfo = token.get("userinfo")
-    if not userinfo:
+    if "preferred_username" not in userinfo:
         try:
-            userinfo = client.userinfo(token=token)
+            fetched_info = client.userinfo(token=token)
+            if fetched_info:
+                userinfo.update(fetched_info)
         except Exception as e:
             app.logger.warning("OIDC userinfo fetch failed: %s", e)
             return redirect(url_for("login") + "?error=oidc_userinfo_failed")


### PR DESCRIPTION
**Problem:**
OIDC Identity Providers like Authelia only include the sub claim in the initial id_token by default. Because token.get("userinfo") returns a non-empty dict containing {"sub": "uuid"}, the condition if not userinfo: evaluates to False. As a result, client.userinfo(token=token) is never executed, and extract_username() falls back to using the sub UUID as the user's username.

**Fix:**
Updated the OIDC callback logic to check whether the required username claim (or preferred_username) exists in userinfo. If missing, it explicitly queries the /userinfo endpoint to fetch the full user profile.